### PR TITLE
[fix] Shift additional options

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -13,7 +13,7 @@ FOPT="\
     --minUptime 10000 --spinSleepTime 600000 \
     -o hubot.log -e hubot-err.log -a \
     -w --watchDirectory scripts/ \
-    -c coffee node_modules/.bin/hubot -a direct $@ \
+    -c coffee node_modules/.bin/hubot -a direct ${@:2:$#} \
 "
 
 if [ "$REDIS_URL" = "" ]; then


### PR DESCRIPTION
daabコマンドから起動した場合、forever経由で渡されるhubotの引数にdaabコマンドへのサブコマンドが含まれています。
$ daab run --name hubot2
と起動すると、
~/node_modules/.bin/hubot -a direct run --name hubot2
このようになります。foreverへわたす引数を２番目以降から引きつぐように修正しました。
