### PR TITLE
Set options for error detection

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eu
+
 npm install
 export PATH="node_modules/.bin:node_modules/lisb-hubot/node_modules/.bin:$PATH"
 
@@ -16,7 +18,7 @@ FOPT="\
     -c coffee node_modules/.bin/hubot -a direct ${@:2:$#} \
 "
 
-if [ "$REDIS_URL" = "" ]; then
+if [ -z "${REDIS_URL-}" ]; then
   export REDIS_URL=redis://localhost:6379/$FID
 fi
 


### PR DESCRIPTION
This PR is small fix.

Bash has 'e' and 'u' option. 'e' option enables to abort script when an error occurred. 'u' option shows error message and aborts script, when an undefined variable is used.
It is desirable to set these options.